### PR TITLE
JS: add javascript monorepo scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# tests
+
+# dists
+dist/*
+**/dist/*
+dist.js
+dist.min.js
+
+.reify-cache
+.nyc_output/
+coverage/
+node_modules/
+npm-debug.log
+stats.json
+package-lock.json
+*/**/yarn.lock
+yarn-error.log
+
+# Misc files
+*.zip
+*.rar
+*.log
+
+# editor files
+.idea
+.project
+.DS_Store

--- a/js/.eslintignore
+++ b/js/.eslintignore
@@ -1,0 +1,12 @@
+dist
+public/
+.cache/
+
+**/src/libs/*
+**/dist/*
+**/wip/*
+
+*.min.js
+
+node_modules/
+bundle.js

--- a/js/.eslintrc.js
+++ b/js/.eslintrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 2018
+  },
+  extends: ['eslint-config-uber-es2015', 'prettier'],
+  rules: {
+    'guard-for-in': 0,
+    'generator-star-spacing': 0,
+    'func-names': 0,
+    'no-inline-comments': 0,
+    'no-multi-str': 0,
+    'space-before-function-paren': 0
+  }
+};

--- a/js/.prettierignore
+++ b/js/.prettierignore
@@ -1,0 +1,12 @@
+dist
+public/
+.cache/
+
+**/src/libs/*
+**/dist/*
+**/wip/*
+
+*.min.js
+
+node_modules/
+bundle.js

--- a/js/.prettierrc
+++ b/js/.prettierrc
@@ -1,0 +1,5 @@
+printWidth: 100
+semi: true
+singleQuote: true
+trailingComma: none
+bracketSpacing: false

--- a/js/babel.config.js
+++ b/js/babel.config.js
@@ -1,0 +1,21 @@
+const getBabelConfig = require('ocular-dev-tools/config/babel.config');
+
+module.exports = api => {
+  const config = getBabelConfig(api);
+
+  config.plugins = config.plugins || [];
+  config.plugins.push('version-inline');
+
+  return {
+    ...config,
+    ignore: [
+      // Don't transpile workers, they are transpiled separately
+      '**/*.worker.js',
+      '**/workers/*.js',
+      // Don't transpile files in libs, we use this folder to store external,
+      // already transpiled and minified libraries and scripts.
+      // e.g. draco, basis, las-perf etc.
+      /src\/libs/
+    ]
+  };
+};

--- a/js/package.json
+++ b/js/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "unfolded.gl-monorepo",
+  "description": "Open Source JavaScript software from Unfolded, Inc",
+  "license": "MIT",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/UnfoldedInc/unfolded.gl"
+  },
+  "keywords": [
+    "unfolded",
+    "webgl",
+    "deck.gl",
+    "luma.gl",
+    "kepler.gl",
+    "loaders.gl"
+  ],
+  "workspaces": [
+    "modules/*"
+  ],
+  "scripts": {
+    "start": "echo 'Please see the unfolded.gl website for how to run examples' && open https://unfold.gl/docs",
+    "bootstrap": "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn && ocular-bootstrap",
+    "build": "ocular-clean && lerna run pre-build && ocular-build",
+    "build-workers": "lerna run pre-build",
+    "clean": "ocular-clean",
+    "cover": "ocular-test cover",
+    "lint": "ocular-lint",
+    "publish": "ocular-publish",
+    "test": "ocular-test",
+    "pre-commit": "ocular-lint",
+    "pre-push": "ocular-test fast",
+    "metrics": "./scripts/metrics.sh && ocular-metrics"
+  },
+  "devDependencies": {
+    "@babel/register": "^7.4.4",
+    "@probe.gl/bench": "^3.2.0",
+    "@probe.gl/test-utils": "^3.1.1",
+    "babel-loader": "^8.0.6",
+    "core-js": "^3.2.1",
+    "coveralls": "^3.0.3",
+    "eslint-config-uber-jsx": "^3.3.3",
+    "eslint-plugin-babel": "^5.3.0",
+    "eslint-plugin-react": "^7.13",
+    "gl": "^4.4.0",
+    "ocular-dev-tools": "^0.1.3",
+    "pre-commit": "^1.2.2",
+    "pre-push": "^0.1.1",
+    "reify": "^0.19.1",
+    "source-map-support": "^0.5.12",
+    "tape-promise": "^4.0.0"
+  },
+  "pre-commit": "pre-commit",
+  "pre-push": "pre-push"
+}

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -1,0 +1,33 @@
+const getWebpackConfig = require('ocular-dev-tools/config/webpack.config');
+
+module.exports = (env = {}) => {
+  const config = getWebpackConfig(env);
+
+  config.module.rules.push({
+    // Load worker tests
+    test: /\.worker\.js$/,
+    use: {
+      loader: 'worker-loader'
+    }
+  });
+
+  // Uncomment to debug config
+  // console.error(JSON.stringify(config, null, 2));
+
+  return [
+    config,
+    // For worker tests
+    // Output bundles to root and can be loaded with `new Worker('/*.worker.js')`
+    {
+      mode: 'development',
+      entry: {
+        'json-loader': './modules/core/test/worker-utils/json-loader.worker.js',
+        'jsonl-loader': './modules/core/test/worker-utils/jsonl-loader.worker.js'
+      },
+      output: {
+        filename: '[name].worker.js'
+      },
+      target: 'webworker'
+    }
+  ];
+};


### PR DESCRIPTION
Some scaffolding that will let us publish open source JS modules. 

Copy-pasta from loaders.gl.

This repo is still private, just prep work.